### PR TITLE
Ensure triage agent routes to all specialist agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ This command will also start the backend.
 
 This app is designed for demonstration purposes. Feel free to update the agent prompts, guardrails, and tools to fit your own educational product workflows or experiment with new use cases! The modular structure makes it easy to extend or modify the orchestration logic for your needs.
 
+## Agents
+
+The backend defines four agents used throughout the demo:
+
+- **Triage Agent** – first contact for any request and delegates to specialists.
+- **Instructional Design Agent** – helps structure outlines and learning objectives.
+- **FAQ Agent** – answers common course creation questions using a lookup tool.
+- **Content Expert Agent** – provides detailed entrepreneurship knowledge and lesson ideas.
+
 ## Demo Flows
 
 ### Demo flow #1

--- a/python-backend/main.py
+++ b/python-backend/main.py
@@ -209,7 +209,12 @@ triage_agent = Agent[CourseDesignContext](
     handoff_description="A triage agent that can delegate a customer's request to the appropriate agent.",
     instructions=(
         f"{RECOMMENDED_PROMPT_PREFIX} "
-        "You are a helpful triaging agent. You can use your tools to delegate questions to other appropriate agents."
+        "You are a helpful triaging agent for course design. "
+        "Route the request to one of the specialist agents when possible:\n"
+        "- Instructional Design Agent: organize outlines and objectives.\n"
+        "- FAQ Agent: answer common course creation questions using tools.\n"
+        "- Content Expert Agent: provide detailed entrepreneurship knowledge.\n"
+        "If none of these apply, respond directly."
     ),
     handoffs=[
         handoff(agent=content_expert_agent, on_handoff=on_content_handoff),


### PR DESCRIPTION
## Summary
- clarify triage agent instructions so it lists FAQ, Instructional Design and Content Expert agents
- document all agents in the README

## Testing
- `python -m py_compile main.py api.py`
- `CI=1 npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6854859473948322ae635180acb65a7a