### PR TITLE
Improve agent routing and add critic agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The backend defines four agents used throughout the demo:
 
 - **Triage Agent** – first contact for any request and delegates to specialists.
 - **Instructional Design Agent** – helps structure outlines and learning objectives.
-- **FAQ Agent** – answers common course creation questions using a lookup tool.
+- **Critic Agent** – reviews answers from other agents and suggests improvements when asked.
 - **Content Expert Agent** – provides detailed entrepreneurship knowledge and lesson ideas.
 
 ## Demo Flows
@@ -103,9 +103,9 @@ This flow shows how the system routes product teams to the right specialists whe
 
 ### Demo flow #2
 
-1. **Ask an FAQ-style question:**
-   - User: "How long should each module be?"
-   - The Triage Agent routes you to the FAQ Agent, which looks up the recommended duration.
+1. **Ask for a quick critique:**
+   - User: "Can you review the outline you gave me?"
+   - The Triage Agent routes you to the Critic Agent, which provides feedback on the proposed plan.
 
 2. **Trigger the Relevance Guardrail:**
    - User: "Tell me a joke about airplanes."

--- a/python-backend/api.py
+++ b/python-backend/api.py
@@ -8,7 +8,7 @@ import logging
 
 from main import (
     triage_agent,
-    faq_agent,
+    critic_agent,
     content_expert_agent,
     instructional_design_agent,
     create_initial_context,
@@ -108,7 +108,7 @@ def _get_agent_by_name(name: str):
     """Return the agent object by name."""
     agents = {
         triage_agent.name: triage_agent,
-        faq_agent.name: faq_agent,
+        critic_agent.name: critic_agent,
         content_expert_agent.name: content_expert_agent,
         instructional_design_agent.name: instructional_design_agent,
     }
@@ -139,7 +139,7 @@ def _build_agents_list() -> List[Dict[str, Any]]:
         }
     return [
         make_agent_dict(triage_agent),
-        make_agent_dict(faq_agent),
+        make_agent_dict(critic_agent),
         make_agent_dict(content_expert_agent),
         make_agent_dict(instructional_design_agent),
     ]
@@ -180,7 +180,8 @@ async def chat_endpoint(req: ChatRequest):
         conversation_id = req.conversation_id  # type: ignore
         state = conversation_store.get(conversation_id)
 
-    current_agent = _get_agent_by_name(state["current_agent"])
+    # Always start with the triage agent to decide routing for this turn
+    current_agent = triage_agent
     state["input_items"].append({"content": req.message, "role": "user"})
     old_context = state["context"].model_dump().copy()
     guardrail_checks: List[GuardrailCheck] = []


### PR DESCRIPTION
## Summary
- route conversations through the triage agent on every turn
- replace FAQ agent with a Critic agent that reviews other agents' work
- update agent lists and triage instructions
- document new Critic agent in the README

## Testing
- `python -m py_compile python-backend/*.py`
- `python -m python-backend.main`
- `npm -v`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854aeac7eac83228abd6fe0e135da8e